### PR TITLE
Fixed deprecated properties

### DIFF
--- a/boards/catie/zest_core_stm32g474ve/zest_core_stm32g474ve.dts
+++ b/boards/catie/zest_core_stm32g474ve/zest_core_stm32g474ve.dts
@@ -100,8 +100,8 @@ zephyr_udc0: &usb {
 			 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 	pinctrl-0 = <&fdcan3_tx_pb4 &fdcan3_rx_pa8>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
+	bitrate = <125000>;
+	bitrate-data = <1000000>;
 	status = "disabled";
 };
 


### PR DESCRIPTION
In **can-controller.yaml**:

```yaml
properties:
  bus-speed:
    type: int
    deprecated: true
    description: |
      Deprecated. This property has been renamed to bitrate.

      Initial bitrate in bit/s. If this is unset, the initial bitrate is set to
      CONFIG_CAN_DEFAULT_BITRATE.
  bitrate:
    type: int
    description: |
      Initial bitrate in bit/s. If this is unset, the initial bitrate is set to
      CONFIG_CAN_DEFAULT_BITRATE.
```

And in **fd-can-controller.yaml**:

```yaml
properties:
  bus-speed-data:
    type: int
    deprecated: true
    description: |
      Deprecated. This property has been renamed to bitrate-data.

      Initial data phase bitrate in bit/s.  If this is unset, the initial data phase bitrate is set
      to CONFIG_CAN_DEFAULT_BITRATE_DATA.
  bitrate-data:
    type: int
    description: |
      Initial data phase bitrate in bit/s.  If this is unset, the initial data phase bitrate is set
      to CONFIG_CAN_DEFAULT_BITRATE_DATA.
```